### PR TITLE
include index properties in type

### DIFF
--- a/tests/src/19-get-index-property.ts
+++ b/tests/src/19-get-index-property.ts
@@ -1,0 +1,22 @@
+import {
+	getType,
+	Type
+} from "tst-reflect";
+import * as ts from "typescript";
+
+test("getType<T>() gets index property", () => {
+	interface ObjectWithIndexProperty
+	{
+		a: string;
+		b: number;
+		[name: string]: string|number;
+	}
+
+	const type = getType<ObjectWithIndexProperty>();
+	const properties = type.getProperties();
+	expect(properties).toHaveLength(3);
+	const indexProp = properties.find(prop => prop.name == ts.InternalSymbolName.Index)!;
+	expect(indexProp.type.types).toHaveLength(2);
+	expect(indexProp.type.types![0].fullName).toBe('String');
+	expect(indexProp.type.types![1].fullName).toBe('Number');
+});


### PR DESCRIPTION
index properties have the form `[name: string]: string|number;`

This does not capture the index type. In the above example it does not capture `string`

If this gets merged you may want to bump the version more than a minor version number since the properties coming back may include this additional index property which may be unexpected by some.